### PR TITLE
fix: adminer in 'stop all'

### DIFF
--- a/py_bentoctl/config.py
+++ b/py_bentoctl/config.py
@@ -55,7 +55,6 @@ BENTO_USERNAME: str = pwd.getpwuid(BENTO_UID).pw_name
 
 MODE = os.getenv("MODE")
 DEV_MODE = MODE == "dev"
-LOCAL_MODE = MODE == "local"
 
 
 def _env_get_bool(var: str, default: bool = False) -> bool:

--- a/py_bentoctl/config.py
+++ b/py_bentoctl/config.py
@@ -55,6 +55,7 @@ BENTO_USERNAME: str = pwd.getpwuid(BENTO_UID).pw_name
 
 MODE = os.getenv("MODE")
 DEV_MODE = MODE == "dev"
+LOCAL_MODE = MODE == "local"
 
 
 def _env_get_bool(var: str, default: bool = False) -> bool:

--- a/py_bentoctl/services.py
+++ b/py_bentoctl/services.py
@@ -154,7 +154,7 @@ def stop_service(compose_service: str) -> None:
 
     if compose_service == "all":
         # special: stop everything
-        subprocess.check_call((*_get_service_specific_compose(compose_service), "down"))
+        subprocess.check_call((*_get_compose_with_files(dev=c.DEV_MODE, local=c.LOCAL_MODE), "down"))
         return
 
     check_service_is_compose(compose_service)

--- a/py_bentoctl/services.py
+++ b/py_bentoctl/services.py
@@ -154,7 +154,7 @@ def stop_service(compose_service: str) -> None:
 
     if compose_service == "all":
         # special: stop everything
-        subprocess.check_call((*_get_compose_with_files(dev=c.DEV_MODE, local=c.LOCAL_MODE), "down"))
+        subprocess.check_call((*_get_compose_with_files(dev=c.DEV_MODE), "down"))
         return
 
     check_service_is_compose(compose_service)


### PR DESCRIPTION
The `services.stop_service` function was trying to use "all" as a service name with `_get_service_specific_compose`, causing the  `dev` param to be always false. Since adminer is in dev an local compose files only, it was never in the list.