### PR TITLE
fix: absolute path for root data dir in bento_dev.env

### DIFF
--- a/etc/bento_dev.env
+++ b/etc/bento_dev.env
@@ -10,7 +10,7 @@ BENTO_CBIOPORTAL_ENABLED=false
 
 # Root data directory on host. Bind volumes for services will be put
 # here as subdirectories and mounted into the relevant containers.
-BENTOV2_ROOT_DATA_DIR=./data
+BENTOV2_ROOT_DATA_DIR=${PWD}/data
 
 # Gateway/domains -----------------------------------------------------
 BENTOV2_DOMAIN=bentov2.local


### PR DESCRIPTION
Using the env var `BENTOV2_ROOT_DATA_DIR=./data` causes unintended directory mounts for services that define a compose file uner `lib/`.

**Expected behaviour:** In dev, all mounts should be under the `data/` directory at the root of the project
**Actual behaviour:** services like gohan that have a lib docker file that relies on BENTOV2_ROOT_DATA_DIR will have their data mount be at the same level as their compose file.

**Problem:** relative path at the level of the compose files
**Solution:** change the variable to use absolute path instead of relative