### PR TITLE
Remove stale values from beacon config

### DIFF
--- a/lib/beacon/config/beacon_config.json
+++ b/lib/beacon/config/beacon_config.json
@@ -1,8 +1,5 @@
 {
-    "useAuth": false,
     "useGohan": true,
-    "maxFilters": 2,
-    "smallCellCountThreshold": 5,
     "endpointSets": [
         "individuals",
         "variants",


### PR DESCRIPTION
Remove stale values from beacon config:
- auth settings now in env
- censorship config now in katsu only 