### PR TITLE
move beacon config to example file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ lib/service-registry/bento_service_registry
 lib/web/bento_web
 
 lib/katsu/config.json
+lib/beacon/config/beacon_config.json
 
 # bento_web
 lib/web/*

--- a/lib/beacon/config/beacon_config.example.json
+++ b/lib/beacon/config/beacon_config.example.json
@@ -1,0 +1,18 @@
+{
+    "useGohan": true,
+    "endpointSets": [
+        "individuals",
+        "variants",
+        "datasets",
+        "cohorts"
+    ],
+    "serviceInfo": {
+        "organization": {
+            "id": "c3g",
+            "name": "Canadian Centre for Computational Genomics",
+            "welcomeUrl": "https://computationalgenomics.ca/",
+            "logoUrl": "https://computationalgenomics.ca/wp-content/uploads/2021/12/c3g_source_logo_small.png",
+            "contactUrl": "https://computationalgenomics.ca/contact-us/"
+        }
+    }
+}


### PR DESCRIPTION
- move `beacon_config.json` to `beacon_config.example.json` so config doesn't get clobbered in migration 
- untrack beacon_config.json
- add welcomeUrl, logoUrl contactUrl to example file