### PR TITLE
add org urls to beacon config

### DIFF
--- a/lib/beacon/config/beacon_config.json
+++ b/lib/beacon/config/beacon_config.json
@@ -10,7 +10,9 @@
         "organization": {
             "id": "c3g",
             "name": "Canadian Centre for Computational Genomics",
-            "url": "https://computationalgenomics.ca/"
+            "welcomeUrl": "https://computationalgenomics.ca/",
+            "logoUrl": "https://computationalgenomics.ca/wp-content/uploads/2021/12/c3g_source_logo_small.png",
+            "contactUrl": "https://computationalgenomics.ca/contact-us/"
         }
     }
 }


### PR DESCRIPTION
Add organization urls to beacon config (welcomeUrl, logoUrl, contactUrl)