### PR TITLE
Modified bento public dev docker yaml to have en/fr_about.html files

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -16,6 +16,8 @@ services:
     volumes:
       - ./repos/public:/bento-public
       - ./packs:/packs
+      - ${PWD}/lib/public/en_about.html:/bento-public/src/public/en_about.html
+      - ${PWD}/lib/public/fr_about.html:/bento-public/src/public/fr_about.html
     environment:
       - BENTO_GIT_NAME
       - BENTO_GIT_EMAIL


### PR DESCRIPTION
Resolves the following issue: Dev container crashes on page load, since it can't find en_about.html and fr_about.html even when they are present in lib/public.

