### PR TITLE
docs: update authz grants instructions for reference genome

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -327,7 +327,7 @@ bento_authz create grant \
   '{"everything": true}' \
   'view:private_portal'
 
-# This grant gives permission to access and ingest data into all projects
+# This grant gives permission to access and ingest data into all projects and the reference genome service
 bento_authz create grant \
   '{"iss": "ISSUER_HERE", "client": "wes"}' \
   '{"everything": true}' \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -331,7 +331,7 @@ bento_authz create grant \
 bento_authz create grant \
   '{"iss": "ISSUER_HERE", "client": "wes"}' \
   '{"everything": true}' \
-  'query:data' 'ingest:data'
+  'query:data' 'ingest:data' 'ingest:reference_material' 'delete:reference_material'
 ```
 
 ### c. *Optional step:* Assign portal access to all users in the instance realm


### PR DESCRIPTION
Base documentation did not include the ingest:reference_genome and delete:reference_genome permissions in the grant creation instructions for authz.