### PR TITLE
chore: bentoctl bump docker-py version to 7.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cffi==1.16.0
 charset-normalizer==3.3.2
 cryptography==42.0.5
 debugpy==1.8.1
-docker==7.0.0
+docker==7.1.0
 flake8==7.0.0
 idna==3.7
 mccabe==0.7.0


### PR DESCRIPTION
_docker-py_ 7.0.0 had issues caused by a dependency change in the _requests_ package.
Was preventing `bentoctl init-docker` when using Docker 27.0.3
See [v7.1.0](https://github.com/docker/docker-py/releases/tag/7.1.0) release notes.