### PR TITLE
fix: grafana oauth email

### DIFF
--- a/lib/logs/docker-compose.logs.yaml
+++ b/lib/logs/docker-compose.logs.yaml
@@ -16,14 +16,15 @@ services:
       - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=${BENTO_GRAFANA_CLIENT_ID}
       - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=${BENTO_GRAFANA_CLIENT_SECRET}
       - GF_AUTH_GENERIC_OAUTH_SCOPES=openid profile offline_access roles
-      - GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH=username
-      - GF_AUTH_GENERIC_OAUTH_NAME_ATTRIBUTE_PATH=full_name
+      - GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH=preferred_username
+      - GF_AUTH_GENERIC_OAUTH_NAME_ATTRIBUTE_PATH=preferred_username
       - GF_AUTH_GENERIC_OAUTH_USE_PKCE=true
       - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://${BENTOV2_AUTH_DOMAIN}/realms/bentov2/protocol/openid-connect/auth
       - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://${BENTOV2_AUTH_DOMAIN}/realms/bentov2/protocol/openid-connect/token
       - GF_AUTH_GENERIC_OAUTH_API_URL=https://${BENTOV2_AUTH_DOMAIN}/realms/bentov2/protocol/openid-connect/userinfo
       - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH='GrafanaAdmin'
-      - GF_AUTH_GENERIC_OAUTH_EMAIL_ATTRIBUTE_PATH='@.email || @.sub'
+      # Allows authentication for users that don't have an email
+      - GF_AUTH_GENERIC_OAUTH_EMAIL_ATTRIBUTE_PATH=email || preferred_username || sub
       - GF_AUTH_ALLOW_ASSIGN_GRAFANA_ADMIN=true
     entrypoint:
       - sh

--- a/lib/logs/docker-compose.logs.yaml
+++ b/lib/logs/docker-compose.logs.yaml
@@ -23,6 +23,7 @@ services:
       - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://${BENTOV2_AUTH_DOMAIN}/realms/bentov2/protocol/openid-connect/token
       - GF_AUTH_GENERIC_OAUTH_API_URL=https://${BENTOV2_AUTH_DOMAIN}/realms/bentov2/protocol/openid-connect/userinfo
       - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH='GrafanaAdmin'
+      - GF_AUTH_GENERIC_OAUTH_EMAIL_ATTRIBUTE_PATH='@.email || @.sub'
       - GF_AUTH_ALLOW_ASSIGN_GRAFANA_ADMIN=true
     entrypoint:
       - sh


### PR DESCRIPTION
Allows Keycloak users with no email to login to Grafana.

https://github.com/grafana/grafana/issues/13549