### PR TITLE
fix: remove adminer from local compose file

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -59,11 +59,6 @@ services:
       - BENTO_GIT_EMAIL
       - BENTO_GIT_REPOSITORY_DIR=/app
 
-  adminer:
-    # No Docker networks required, bound to host
-    ports:
-      - 8080:8080
-
   aggregation:
     image: ${BENTOV2_AGGREGATION_IMAGE}:${BENTOV2_AGGREGATION_VERSION_DEV}
     environment:


### PR DESCRIPTION
Was causing bentoctl to create 2 adminer containers in dev mode on some docker compose versions, leading to a port conflict.
Should not have been there to begin with, since the local compose is to mount code repositories for local dev.