### PR TITLE
[17] Fixes/beacon wait for auth

### DIFF
--- a/lib/beacon/docker-compose.beacon.yaml
+++ b/lib/beacon/docker-compose.beacon.yaml
@@ -34,6 +34,9 @@ services:
       - beacon-net
       - gohan-api-net
       - katsu-net
+    depends_on:
+      auth:
+        condition: service_healthy
     expose:
       - ${BENTO_BEACON_INTERNAL_PORT}
     mem_limit: ${BENTO_BEACON_MEM_LIM} # for mem_limit to work, make sure docker-compose is v2.4


### PR DESCRIPTION
- don't launch beacon container until auth is ready 
- beacon network init is done at app start, so requires auth to be up
