### PR TITLE
add environment variables for auth service

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -100,7 +100,7 @@ services:
 
   auth:
     environment:
-      - BENTO_DEBUG=True
+      # Allows hot reload of changes to theme
       - KC_SPI_THEME_STATIC_MAX_AGE=-1
       - KC_SPI_THEME_CACHE_THEMES=false
       - KC_SPI_THEME_CACHE_TEMPLATES=false

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -68,7 +68,7 @@ services:
           - ${BENTOV2_PORTAL_DOMAIN}
           - ${BENTOV2_AUTH_DOMAIN}
       monitoring-net:
-          aliases:
+        aliases:
           - ${BENTOV2_DOMAIN}
           - ${BENTOV2_PORTAL_DOMAIN}
           - ${BENTOV2_AUTH_DOMAIN}
@@ -97,6 +97,13 @@ services:
           - ${BENTOV2_DOMAIN}
           - ${BENTOV2_PORTAL_DOMAIN}
           - ${BENTOV2_AUTH_DOMAIN}
+
+  auth:
+    environment:
+      - BENTO_DEBUG=True
+      - KC_SPI_THEME_STATIC_MAX_AGE=-1
+      - KC_SPI_THEME_CACHE_THEMES=false
+      - KC_SPI_THEME_CACHE_TEMPLATES=false
 
   authz:
     environment:
@@ -243,9 +250,9 @@ services:
     ports:
       - "3000:3000"
     environment:
-    # Workaround for self signed certificates in dev
+      # Workaround for self signed certificates in dev
       - GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE=true
-  
+
   loki:
     ports:
       - "3100:3100"

--- a/lib/auth/docker-compose.auth.yaml
+++ b/lib/auth/docker-compose.auth.yaml
@@ -34,7 +34,7 @@ services:
     cpus: ${BENTOV2_AUTH_CPUS}
     cpu_shares: 512
     healthcheck:
-      test: ["CMD", "bash", "/healthcheck.bash"]
+      test: [ "CMD", "bash", "/healthcheck.bash" ]
       timeout: ${BENTO_HEALTHCHECK_TIMEOUT}
       # interval: ${BENTO_HEALTHCHECK_INTERVAL}
       # For Docker <25 and Compose <2.24.x, start_interval doesn't work - use a shorter interval for now
@@ -56,16 +56,7 @@ services:
     volumes:
       - ${BENTOV2_AUTH_VOL_DIR}:/var/lib/postgresql/data
     healthcheck:
-      test:
-        [
-          "CMD",
-          "pg_isready",
-          "-q",
-          "-d",
-          "${BENTO_AUTH_DB}",
-          "-U",
-          "${BENTO_AUTH_DB_USER}",
-        ]
+      test: [ "CMD", "pg_isready", "-q", "-d", "${BENTO_AUTH_DB}", "-U", "${BENTO_AUTH_DB_USER}" ]
       timeout: ${BENTO_HEALTHCHECK_TIMEOUT}
       # interval: ${BENTO_HEALTHCHECK_INTERVAL}
       # For Docker <25 and Compose <2.24.x, start_interval doesn't work - use a shorter interval for now

--- a/lib/auth/docker-compose.auth.yaml
+++ b/lib/auth/docker-compose.auth.yaml
@@ -30,15 +30,11 @@ services:
       - KC_HTTPS_CERTIFICATE_FILE
       - KC_HTTPS_CERTIFICATE_KEY_FILE
       - KC_PROXY_HEADERS
-      # The below environment variables enable hot reloading of themes (useful for development)
-      # - KC_SPI_THEME_STATIC_MAX_AGE=-1
-      # - KC_SPI_THEME_CACHE_THEMES=false
-      # - KC_SPI_THEME_CACHE_TEMPLATES=false
     mem_limit: ${BENTOV2_AUTH_MEM_LIM} # for mem_limit to work, make sure docker-compose is v2.4
     cpus: ${BENTOV2_AUTH_CPUS}
     cpu_shares: 512
     healthcheck:
-      test: [ "CMD", "bash", "/healthcheck.bash" ]
+      test: ["CMD", "bash", "/healthcheck.bash"]
       timeout: ${BENTO_HEALTHCHECK_TIMEOUT}
       # interval: ${BENTO_HEALTHCHECK_INTERVAL}
       # For Docker <25 and Compose <2.24.x, start_interval doesn't work - use a shorter interval for now
@@ -60,7 +56,16 @@ services:
     volumes:
       - ${BENTOV2_AUTH_VOL_DIR}:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD", "pg_isready", "-q", "-d", "${BENTO_AUTH_DB}", "-U", "${BENTO_AUTH_DB_USER}" ]
+      test:
+        [
+          "CMD",
+          "pg_isready",
+          "-q",
+          "-d",
+          "${BENTO_AUTH_DB}",
+          "-U",
+          "${BENTO_AUTH_DB_USER}",
+        ]
       timeout: ${BENTO_HEALTHCHECK_TIMEOUT}
       # interval: ${BENTO_HEALTHCHECK_INTERVAL}
       # For Docker <25 and Compose <2.24.x, start_interval doesn't work - use a shorter interval for now
@@ -77,4 +82,3 @@ networks:
   auth-db-net:
     external: true
     name: ${BENTO_AUTH_DB_NETWORK}
-    


### PR DESCRIPTION
Moved development environment comment from `lib/auth/docker-compose.auth.yaml` to `docker-compose.dev.yaml` to have a dev environment for auth