### PR TITLE
fix: don't rely on auth for beacon startup

### DIFF
--- a/lib/beacon/docker-compose.beacon.yaml
+++ b/lib/beacon/docker-compose.beacon.yaml
@@ -35,9 +35,6 @@ services:
       - beacon-net
       - gohan-api-net
       - katsu-net
-    depends_on:
-      auth:
-        condition: service_healthy
     expose:
       - ${BENTO_BEACON_INTERNAL_PORT}
     mem_limit: ${BENTO_BEACON_MEM_LIM} # for mem_limit to work, make sure docker-compose is v2.4


### PR DESCRIPTION
Should fix external IdP issue. https://redmine.c3g-app.sd4h.ca/issues/2528