### PR TITLE
feat: translated logo option for Bento Public

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -19,7 +19,9 @@ services:
       - ${PWD}/lib/public/en_about.html:/bento-public/src/public/en_about.html
       - ${PWD}/lib/public/fr_about.html:/bento-public/src/public/fr_about.html
       - ${PWD}/lib/public/branding.png:/bento-public/src/public/assets/branding.png
+      - ${PWD}/lib/public/branding.fr.png:/bento-public/src/public/assets/branding.fr.png
       - ${PWD}/lib/public/branding.lightbg.png:/bento-public/src/public/assets/branding.lightbg.png
+      - ${PWD}/lib/public/branding.lightbg.fr.png:/bento-public/src/public/assets/branding.lightbg.fr.png
       - ${PWD}/lib/public/translations/en.json:/bento-public/src/public/locales/en/translation_en.json
       - ${PWD}/lib/public/translations/fr.json:/bento-public/src/public/locales/fr/translation_fr.json
     environment:

--- a/etc/bento_deploy.env
+++ b/etc/bento_deploy.env
@@ -20,6 +20,8 @@ BENTO_GARAGE_ENABLED='false'
 #  - Display flags for Bento portals
 #    - Switch to enable French translation in Bento Public
 BENTO_PUBLIC_TRANSLATED='true'
+#    - Switch for whether logo is translated (or whether translation is relevant to the logo, i.e., there's text)
+BENTO_PUBLIC_TRANSLATED_LOGO='false'
 #    - Switch to enable header title text
 BENTO_PUBLIC_SHOW_HEADER_TITLE='true'
 #    - Switches to enable various links in the Bento Public header (these default to being on)

--- a/etc/bento_dev.env
+++ b/etc/bento_dev.env
@@ -20,6 +20,8 @@ BENTO_GARAGE_ENABLED='false'
 #  - Display flags for Bento portals
 #    - Switch to enable French translation in Bento Public
 BENTO_PUBLIC_TRANSLATED='true'
+#    - Switch for whether logo is translated (or whether translation is relevant to the logo, i.e., there's text)
+BENTO_PUBLIC_TRANSLATED_LOGO='false'
 #    - Switch to enable header title text
 BENTO_PUBLIC_SHOW_HEADER_TITLE='true'
 #    - Switches to enable various links in the Bento Public header (these default to being on)

--- a/etc/default_config.env
+++ b/etc/default_config.env
@@ -25,6 +25,8 @@ BENTO_GARAGE_ENABLED='false'
 #  - Display flags for Bento portals
 #    - Switch to enable French translation in Bento Public
 BENTO_PUBLIC_TRANSLATED='true'
+#    - Switch for whether logo is translated (or whether translation is relevant to the logo, i.e., there's text)
+BENTO_PUBLIC_TRANSLATED_LOGO='false'
 #    - Switch to enable header title text
 BENTO_PUBLIC_SHOW_HEADER_TITLE='true'
 #    - Switches to enable various links in the Bento Public header (these default to being on)

--- a/lib/public/docker-compose.public.yaml
+++ b/lib/public/docker-compose.public.yaml
@@ -13,6 +13,7 @@ services:
       - BENTO_PUBLIC_CLIENT_NAME
       - BENTO_PUBLIC_PORTAL_URL
       - BENTO_PUBLIC_TRANSLATED
+      - BENTO_PUBLIC_TRANSLATED_LOGO
       - BENTO_PUBLIC_SHOW_HEADER_TITLE
       - BENTO_PUBLIC_SHOW_PORTAL_LINK
       - BENTO_PUBLIC_SHOW_SIGN_IN
@@ -37,7 +38,9 @@ services:
       - ${PWD}/lib/public/fr_about.html:/bento-public/dist/public/fr_about.html:ro
 
       - ${PWD}/lib/public/branding.png:/bento-public/dist/public/assets/branding.png:ro
+      - ${PWD}/lib/public/branding.fr.png:/bento-public/dist/public/assets/branding.fr.png:ro
       - ${PWD}/lib/public/branding.lightbg.png:/bento-public/dist/public/assets/branding.lightbg.png:ro
+      - ${PWD}/lib/public/branding.lightbg.fr.png:/bento-public/dist/public/assets/branding.lightbg.fr.png:ro
       - ${PWD}/lib/public/favicon.png:/bento-public/dist/public/assets/icon_small.png:ro
     healthcheck:
       test: [ "CMD", "curl", "http://localhost:${BENTO_PUBLIC_INTERNAL_PORT}/service-info" ]

--- a/py_bentoctl/other_helpers.py
+++ b/py_bentoctl/other_helpers.py
@@ -63,17 +63,11 @@ def _init_web_public(force: bool):
 
     # Branding image
     # - dark background / default
-    _file_copy(
-        (etc_path / "default.branding.png"),
-        (public_path / "branding.png"),
-        force=force,
-    )
+    _file_copy(etc_path / "default.branding.png", public_path / "branding.png", force=force)
+    _file_copy(etc_path / "default.branding.png", public_path / "branding.fr.png", force=force)
     # - light background
-    _file_copy(
-        (etc_path / "default.branding.lightbg.png"),
-        (public_path / "branding.lightbg.png"),
-        force=force,
-    )
+    _file_copy(etc_path / "default.branding.lightbg.png", public_path / "branding.lightbg.png", force=force)
+    _file_copy(etc_path / "default.branding.lightbg.png", public_path / "branding.lightbg.fr.png", force=force)
 
     # - favicon
     _file_copy(


### PR DESCRIPTION
see also https://github.com/bento-platform/bento_public/pull/373

must stop Bento Public, then run `./bentoctl.bash init-web public` to copy new french logo placeholder file over before starting it again.