### PR TITLE
feat(ci): Add bentoctl Dockerfile and build/publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,20 @@ jobs:
       - name: Test image (show help output)
         run: docker run bentoctl:test bentoctl
 
+      - name: Build dev image for testing
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: dev.Dockerfile
+          push: false
+          load: true
+          tags: ghcr.io/bento-platform/bentoctl:test-dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test dev image (show help output)
+        run: docker run -v ./py_bentoctl:/bentoctl/py_bentoctl ghcr.io/bento-platform/bentoctl:test-dev bentoctl
+
       - name: Run Bento build action
         uses: bento-platform/bento_build_action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build and push bentoctl
+on:
+  release:
+    types: [ published ]
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build-test-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image for testing
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: bentoctl:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test image (show help output)
+        run: docker run bentoctl:test bentoctl
+
+      - name: Run Bento build action
+        uses: bento-platform/bento_build_action@v1
+        with:
+          registry: ghcr.io
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+          image-name: ghcr.io/bento-platform/bentoctl
+          development-dockerfile: dev.Dockerfile
+          dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM python:3.14-slim
+
+WORKDIR /bentoctl
+
+# docker compose config (used by py_bentoctl/config.py to enumerate enabled services) needs the
+# docker CLI + compose plugin present, even though no daemon is running in this container.
+# Debian's own `docker.io` package doesn't ship a `docker` client binary, so we use Docker's
+# official apt repo instead, and only install the CLI + compose plugin (no engine/daemon).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY py_bentoctl py_bentoctl
+COPY requirements.txt .
+COPY bentoctl.bash .
+COPY docker-compose.yaml .
+COPY lib lib
+COPY etc/default_config.env etc/default_config.env
+COPY etc/bento.env etc/bento.env
+COPY etc/bento_post_config.bash etc/bento_post_config.bash
+COPY etc/bento_services.json etc/bento_services.json
+
+RUN chmod +x bentoctl.bash
+
+# Create and activate a venv, then install Python dependencies into it
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Create a `bentoctl` shell alias for bentoctl.bash
+RUN echo "alias bentoctl='/bentoctl/bentoctl.bash'" >> /etc/bash.bashrc
+
+# Use an interactive shell as the entrypoint so the alias above is picked up
+# even for non-interactive `docker run <image> bentoctl` invocations.
+ENTRYPOINT [ "/bin/bash", "-ic" ]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin && \
     rm -rf /var/lib/apt/lists/*
 
-COPY py_bentoctl py_bentoctl
 COPY requirements.txt .
 COPY bentoctl.bash .
 COPY docker-compose.yaml .

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,43 @@
+# NOTE: bentoctl has no real "dev" mode/workflow at the moment — this file exists only because
+# bento_build_action currently requires a development-dockerfile input to build from.
+# It mirrors Dockerfile for now.
+# TODO: remove this once bento_build_action supports an optional dev Dockerfile.
+
+FROM python:3.14-slim
+
+WORKDIR /bentoctl
+
+# docker compose config (used by py_bentoctl/config.py to enumerate enabled services) needs the
+# docker CLI + compose plugin present, even though no daemon is running in this container.
+# Debian's own `docker.io` package doesn't ship a `docker` client binary, so we use Docker's
+# official apt repo instead, and only install the CLI + compose plugin (no engine/daemon).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY py_bentoctl py_bentoctl
+COPY requirements.txt .
+COPY bentoctl.bash .
+COPY docker-compose.yaml .
+COPY lib lib
+COPY etc/default_config.env etc/default_config.env
+COPY etc/bento.env etc/bento.env
+COPY etc/bento_post_config.bash etc/bento_post_config.bash
+COPY etc/bento_services.json etc/bento_services.json
+
+RUN chmod +x bentoctl.bash
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir -r requirements.txt
+
+RUN echo "alias bentoctl='/bentoctl/bentoctl.bash'" >> /etc/bash.bashrc
+
+ENTRYPOINT [ "/bin/bash", "-ic" ]

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -23,7 +23,7 @@ __all__ = ["init_auth"]
 urllib3.disable_warnings(InsecureRequestWarning)
 
 USE_EXTERNAL_IDP = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
-CREATE_TEST_USER = os.getenv("BENTOV2_AUTH_CREATE_TEST_USER") in ("1", "true")
+CREATE_TEST_USER = os.getenv("BENTO_AUTH_CREATE_TEST_USER") in ("1", "true")
 CLIENT_ID = os.getenv("BENTOV2_AUTH_CLIENT_ID")
 
 PUBLIC_URL = os.getenv("BENTOV2_PUBLIC_URL")
@@ -642,12 +642,12 @@ def init_auth(docker_client: Optional[docker.DockerClient] = None):
         )
         success()
 
-    if not USE_EXTERNAL_IDP or CREATE_TEST_USER:
+    if CREATE_TEST_USER:
         info(f"  Creating user: {AUTH_TEST_USER}")
         create_test_user_if_needed(access_token)
         success()
     else:
-        warn("  Skipping test user creation as we are using an external Keycloak instance.")
+        warn("  Skipping test user creation, set BENTO_AUTH_CREATE_TEST_USER=true to enable it.")
 
     if not USE_EXTERNAL_IDP:
         if docker_client is not None:

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -23,6 +23,7 @@ __all__ = ["init_auth"]
 urllib3.disable_warnings(InsecureRequestWarning)
 
 USE_EXTERNAL_IDP = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
+CREATE_TEST_USER = os.getenv("BENTOV2_AUTH_CREATE_TEST_USER") in ("1", "true")
 CLIENT_ID = os.getenv("BENTOV2_AUTH_CLIENT_ID")
 
 PUBLIC_URL = os.getenv("BENTOV2_PUBLIC_URL")
@@ -334,7 +335,7 @@ def create_client_and_secret_for_service(
     )
 
 
-def init_auth(docker_client: docker.DockerClient):
+def init_auth(docker_client: Optional[docker.DockerClient] = None):
     target_realm = AUTH_REALM if USE_EXTERNAL_IDP else MASTER_REALM
 
     # Capture admin credentials from the function
@@ -586,14 +587,15 @@ def init_auth(docker_client: docker.DockerClient):
     idp_type = "external" if USE_EXTERNAL_IDP else "internal"
     info(f"[bentoctl] Using {idp_type} IdP, setting up Keycloak... (DEV_MODE={c.DEV_MODE})")
 
-    try:
-        docker_client.containers.get(GATEWAY_CONTAINER_NAME)  # Needed to access Keycloak through the proper channel
-        docker_client.containers.get(AUTH_CONTAINER_NAME)
-    except requests.exceptions.HTTPError:
-        info(f"  Starting {AUTH_CONTAINER_NAME}...")
-        # Not found, so we need to start it
-        subprocess.check_call((*c.COMPOSE, "up", "--wait", "-d", "auth", "gateway"))
-        success()
+    if docker_client is not None:
+        try:
+            docker_client.containers.get(GATEWAY_CONTAINER_NAME)  # Needed to access Keycloak through the proper channel
+            docker_client.containers.get(AUTH_CONTAINER_NAME)
+        except requests.exceptions.HTTPError:
+            info(f"  Starting {AUTH_CONTAINER_NAME}...")
+            # Not found, so we need to start it
+            subprocess.check_call((*c.COMPOSE, "up", "--wait", "-d", "auth", "gateway"))
+            success()
 
     info(f"   Signing into {target_realm} realm as {AUTH_ADMIN_USER}...")
     session = get_session()
@@ -640,7 +642,7 @@ def init_auth(docker_client: docker.DockerClient):
         )
         success()
 
-    if not USE_EXTERNAL_IDP:
+    if not USE_EXTERNAL_IDP or CREATE_TEST_USER:
         info(f"  Creating user: {AUTH_TEST_USER}")
         create_test_user_if_needed(access_token)
         success()
@@ -648,14 +650,15 @@ def init_auth(docker_client: docker.DockerClient):
         warn("  Skipping test user creation as we are using an external Keycloak instance.")
 
     if not USE_EXTERNAL_IDP:
-        info("  Restarting the Keycloak container")
-        try:
-            kc = docker_client.containers.get(AUTH_CONTAINER_NAME)
-            kc.restart()
-            success()
-        except requests.exceptions.HTTPError:
-            # Not found
-            err(f"    Could not find container: {AUTH_CONTAINER_NAME}. Is it running?")
+        if docker_client is not None:
+            info("  Restarting the Keycloak container")
+            try:
+                kc = docker_client.containers.get(AUTH_CONTAINER_NAME)
+                kc.restart()
+                success()
+            except requests.exceptions.HTTPError:
+                # Not found
+                err(f"    Could not find container: {AUTH_CONTAINER_NAME}. Is it running?")
 
     if not USE_EXTERNAL_IDP:
         # Copy branding file from cwd/etc/default.branding.lightbg.png

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -27,6 +27,7 @@ USE_EXTERNAL_IDP = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
 CREATE_TEST_USER = os.getenv("BENTO_AUTH_CREATE_TEST_USER") in ("1", "true")
 CREATE_REALM = os.getenv("BENTO_AUTH_CREATE_REALM") in ("1", "true")
 AUTH_ADMIN_REALM = os.getenv("BENTO_AUTH_ADMIN_REALM", "")
+K8S_NAMESPACE = os.getenv("BENTO_K8S_NAMESPACE", "default")
 CLIENT_ID = os.getenv("BENTOV2_AUTH_CLIENT_ID")
 
 PUBLIC_URL = os.getenv("BENTOV2_PUBLIC_URL")
@@ -341,14 +342,14 @@ def create_client_and_secret_for_service(
     if k8s_client is not None:
         secret_name = f"{client_id}-oidc-secret"
         try:
-            k8s_client.delete_namespaced_secret(name=secret_name, namespace="default")
+            k8s_client.delete_namespaced_secret(name=secret_name, namespace=K8S_NAMESPACE)
         except client.exceptions.ApiException as e:
             # 404 means the secret doesn't exist yet (first run) — nothing to delete, safe to continue.
             # Any other error is unexpected and should propagate.
             if e.status != 404:
                 raise
         k8s_client.create_namespaced_secret(
-            namespace="default",
+            namespace=K8S_NAMESPACE,
             body=client.V1Secret(
                 metadata=client.V1ObjectMeta(name=secret_name),
                 string_data={"id": client_kc_id, "secret": client_secret},

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -2,6 +2,7 @@
 
 import docker
 import json
+from kubernetes import client
 import os
 import requests
 import subprocess
@@ -24,6 +25,7 @@ urllib3.disable_warnings(InsecureRequestWarning)
 
 USE_EXTERNAL_IDP = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
 CREATE_TEST_USER = os.getenv("BENTO_AUTH_CREATE_TEST_USER") in ("1", "true")
+CREATE_REALM = os.getenv("BENTO_AUTH_CREATE_REALM") in ("1", "true")
 AUTH_ADMIN_REALM = os.getenv("BENTO_AUTH_ADMIN_REALM", "")
 CLIENT_ID = os.getenv("BENTOV2_AUTH_CLIENT_ID")
 
@@ -119,11 +121,11 @@ def fetch_existing_client_id(token: str, client_id: str, verbose: bool = True) -
         err(f"    Failed to fetch existing clients: {existing_clients}")
         exit(1)
 
-    for client in existing_clients:
-        if client["clientId"] == client_id:
+    for kc_client in existing_clients:
+        if kc_client["clientId"] == client_id:
             if verbose:
                 warn(f"    Found existing client: {client_id}; using that.")
-            return client["id"]
+            return kc_client["id"]
 
     return None
 
@@ -300,6 +302,7 @@ def create_client_and_secret_for_service(
     to_restart: str = "the gateway",
     token_lifespan: int = 900,    # default access token lifespan: 15 minutes
     use_refresh_tokens: bool = False,  # by default, don't use refresh tokens! (they're less secure)
+    k8s_client: Optional[client.CoreV1Api] = None,
 ):
     client_kc_id: Optional[str] = fetch_existing_client_id(token, client_id)
 
@@ -335,8 +338,32 @@ def create_client_and_secret_for_service(
         attrs=["bold"],
     )
 
+    if k8s_client is not None:
+        secret_name = f"{client_id}-oidc-secret"
+        try:
+            k8s_client.delete_namespaced_secret(name=secret_name, namespace="default")
+        except client.exceptions.ApiException as e:
+            # 404 means the secret doesn't exist yet (first run) — nothing to delete, safe to continue.
+            # Any other error is unexpected and should propagate.
+            if e.status != 404:
+                raise
+        k8s_client.create_namespaced_secret(
+            namespace="default",
+            body=client.V1Secret(
+                metadata=client.V1ObjectMeta(name=secret_name),
+                string_data={"id": client_kc_id, "secret": client_secret},
+            ),
+        )
+        info(f"    Created Kubernetes secret: {secret_name}")
 
-def init_auth(docker_client: Optional[docker.DockerClient] = None):
+
+def init_auth(
+    docker_client: Optional[docker.DockerClient] = None,
+    k8s_client: Optional[client.CoreV1Api] = None,
+):
+    if docker_client is not None and k8s_client is not None:
+        raise ValueError("init_auth: only one of docker_client or k8s_client may be provided, not both")
+
     target_realm = AUTH_ADMIN_REALM or (AUTH_REALM if USE_EXTERNAL_IDP else MASTER_REALM)
 
     # Capture admin credentials from the function
@@ -445,7 +472,8 @@ def init_auth(docker_client: Optional[docker.DockerClient] = None):
 
     def create_grafana_client_if_needed(token: str) -> None:
         create_client_and_secret_for_service(
-            GRAFANA_CLIENT_ID, "BENTO_GRAFANA_CLIENT_SECRET", GRAFANA_PRIVATE_URL, token, to_restart="Grafana"
+            GRAFANA_CLIENT_ID, "BENTO_GRAFANA_CLIENT_SECRET", GRAFANA_PRIVATE_URL, token, to_restart="Grafana",
+            k8s_client=k8s_client,
         )
 
     def create_grafana_client_roles_if_needed(token: str, client_id: str) -> Optional[dict]:
@@ -519,12 +547,14 @@ def init_auth(docker_client: Optional[docker.DockerClient] = None):
             token,
             is_service_account=True,
             to_restart="Aggregation and Beacon",
+            k8s_client=k8s_client,
         )
 
     # noinspection PyUnusedLocal
     def create_cbioportal_client_if_needed(token: str) -> None:
         create_client_and_secret_for_service(
-            CBIOPORTAL_CLIENT_ID, "BENTO_CBIOPORTAL_CLIENT_SECRET", CBIOPORTAL_URL, token, use_refresh_tokens=True
+            CBIOPORTAL_CLIENT_ID, "BENTO_CBIOPORTAL_CLIENT_SECRET", CBIOPORTAL_URL, token, use_refresh_tokens=True,
+            k8s_client=k8s_client,
         )
 
     def create_wes_client_if_needed(token: str) -> None:
@@ -536,6 +566,7 @@ def init_auth(docker_client: Optional[docker.DockerClient] = None):
             is_service_account=True,
             to_restart="WES",
             token_lifespan=WES_WORKFLOW_TIMEOUT,
+            k8s_client=k8s_client,
         )
 
     def create_test_user_if_needed(token: str) -> None:
@@ -603,12 +634,12 @@ def init_auth(docker_client: Optional[docker.DockerClient] = None):
     access_token = session["access_token"]
     success()
 
-    if not USE_EXTERNAL_IDP:
+    if CREATE_REALM:
         info(f"  Creating realm: {AUTH_REALM}")
         create_realm_if_needed(access_token, login_theme="bento-theme")
         success()
     else:
-        warn("  Skipping realm creation as we are using an external Keycloak instance.")
+        warn("  Skipping realm creation, set BENTO_AUTH_CREATE_REALM=true to enable it.")
 
     info(f"  Creating web client: {AUTH_CLIENT_ID}")
     create_web_client_if_needed(access_token)

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -24,6 +24,7 @@ urllib3.disable_warnings(InsecureRequestWarning)
 
 USE_EXTERNAL_IDP = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
 CREATE_TEST_USER = os.getenv("BENTO_AUTH_CREATE_TEST_USER") in ("1", "true")
+AUTH_ADMIN_REALM = os.getenv("BENTO_AUTH_ADMIN_REALM", "")
 CLIENT_ID = os.getenv("BENTOV2_AUTH_CLIENT_ID")
 
 PUBLIC_URL = os.getenv("BENTOV2_PUBLIC_URL")
@@ -336,7 +337,7 @@ def create_client_and_secret_for_service(
 
 
 def init_auth(docker_client: Optional[docker.DockerClient] = None):
-    target_realm = AUTH_REALM if USE_EXTERNAL_IDP else MASTER_REALM
+    target_realm = AUTH_ADMIN_REALM or (AUTH_REALM if USE_EXTERNAL_IDP else MASTER_REALM)
 
     # Capture admin credentials from the function
     admin_user, admin_password = get_admin_credentials()

--- a/py_bentoctl/config.py
+++ b/py_bentoctl/config.py
@@ -29,6 +29,7 @@ __all__ = [
 
     "MODE",
     "DEV_MODE",
+    "BENTO_PLATFORM",
 
     "BENTO_OPTIONAL_FEATURES",
     "BENTO_OPTIONAL_FEATURES_BY_PROFILE",
@@ -71,6 +72,8 @@ BENTO_USERNAME: str = pwd.getpwuid(BENTO_UID).pw_name
 
 MODE = os.getenv("MODE")
 DEV_MODE = MODE == "dev"
+
+BENTO_PLATFORM = os.getenv("BENTO_PLATFORM", "docker")
 
 SERVICE_LITERAL_ALL: str = "all"
 
@@ -165,16 +168,23 @@ def _get_enabled_services(
                 break  # escape profile loop, we found one which enables this service
 
 
-BASE_SERVICES: Tuple[str, ...] = tuple(_get_enabled_services((DOCKER_COMPOSE_FILE_BASE,), ()))
+if BENTO_PLATFORM == "docker":
+    BASE_SERVICES: Tuple[str, ...] = tuple(_get_enabled_services((DOCKER_COMPOSE_FILE_BASE,), ()))
 
-# Load dev docker-compose services list if in DEV_MODE
-DOCKER_COMPOSE_DEV_SERVICES: Tuple[str, ...] = tuple(
-    _get_enabled_services((DOCKER_COMPOSE_FILE_BASE, DOCKER_COMPOSE_FILE_DEV), BASE_SERVICES)) if DEV_MODE else ()
+    # Load dev docker-compose services list if in DEV_MODE
+    DOCKER_COMPOSE_DEV_SERVICES: Tuple[str, ...] = tuple(
+        _get_enabled_services((DOCKER_COMPOSE_FILE_BASE, DOCKER_COMPOSE_FILE_DEV), BASE_SERVICES)) if DEV_MODE else ()
 
-# Final amalgamation of services for Bento taking into account dev/prod mode + profiles
-DOCKER_COMPOSE_SERVICES: Tuple[str, ...] = BASE_SERVICES + DOCKER_COMPOSE_DEV_SERVICES
-# For use by CLI service arguments: adds in an `all` option, meaning all services:
-DOCKER_COMPOSE_SERVICES_PLUS_ALL: Tuple[str, ...] = (*DOCKER_COMPOSE_SERVICES, SERVICE_LITERAL_ALL)
+    # Final amalgamation of services for Bento taking into account dev/prod mode + profiles
+    DOCKER_COMPOSE_SERVICES: Tuple[str, ...] = BASE_SERVICES + DOCKER_COMPOSE_DEV_SERVICES
+    # For use by CLI service arguments: adds in an `all` option, meaning all services:
+    DOCKER_COMPOSE_SERVICES_PLUS_ALL: Tuple[str, ...] = (*DOCKER_COMPOSE_SERVICES, SERVICE_LITERAL_ALL)
+else:
+    # Not a Docker Compose deployment (e.g. Kubernetes) - Compose services aren't applicable.
+    BASE_SERVICES: Tuple[str, ...] = ()
+    DOCKER_COMPOSE_DEV_SERVICES: Tuple[str, ...] = ()
+    DOCKER_COMPOSE_SERVICES: Tuple[str, ...] = ()
+    DOCKER_COMPOSE_SERVICES_PLUS_ALL: Tuple[str, ...] = (SERVICE_LITERAL_ALL,)
 
 
 BENTO_SERVICES_PATH = os.getenv("BENTO_SERVICES", pathlib.Path(__file__).parent.parent / "etc" / "bento_services.json")

--- a/py_bentoctl/entry.py
+++ b/py_bentoctl/entry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import argparse
+import os
 import subprocess
 import sys
 
@@ -33,7 +34,8 @@ class InitAuth(SubCommand):
 
     @staticmethod
     def exec(args):
-        init_auth(docker_client=u.get_docker_client())
+        use_external_idp = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
+        init_auth(docker_client=None if use_external_idp else u.get_docker_client())
 
 
 class Run(SubCommand):

--- a/py_bentoctl/entry.py
+++ b/py_bentoctl/entry.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 
 from abc import ABC, abstractmethod
-from kubernetes import client, config as k8s_config
 from pathlib import Path
 
 from .auth_helper import init_auth
@@ -40,10 +39,7 @@ class InitAuth(SubCommand):
 
         docker_client = None if (use_external_idp or use_kubernetes) else u.get_docker_client()
 
-        k8s_client = None
-        if use_kubernetes:
-            k8s_config.load_incluster_config()
-            k8s_client = client.CoreV1Api()
+        k8s_client = u.get_k8s_client() if use_kubernetes else None
 
         init_auth(docker_client=docker_client, k8s_client=k8s_client)
 

--- a/py_bentoctl/entry.py
+++ b/py_bentoctl/entry.py
@@ -35,7 +35,8 @@ class InitAuth(SubCommand):
     @staticmethod
     def exec(args):
         use_external_idp = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
-        init_auth(docker_client=None if use_external_idp else u.get_docker_client())
+        use_kubernetes = c.BENTO_PLATFORM == "kubernetes"
+        init_auth(docker_client=None if use_external_idp or use_kubernetes else u.get_docker_client())
 
 
 class Run(SubCommand):

--- a/py_bentoctl/entry.py
+++ b/py_bentoctl/entry.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 
 from abc import ABC, abstractmethod
+from kubernetes import client, config as k8s_config
 from pathlib import Path
 
 from .auth_helper import init_auth
@@ -36,7 +37,15 @@ class InitAuth(SubCommand):
     def exec(args):
         use_external_idp = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
         use_kubernetes = c.BENTO_PLATFORM == "kubernetes"
-        init_auth(docker_client=None if use_external_idp or use_kubernetes else u.get_docker_client())
+
+        docker_client = None if (use_external_idp or use_kubernetes) else u.get_docker_client()
+
+        k8s_client = None
+        if use_kubernetes:
+            k8s_config.load_incluster_config()
+            k8s_client = client.CoreV1Api()
+
+        init_auth(docker_client=docker_client, k8s_client=k8s_client)
 
 
 class Run(SubCommand):

--- a/py_bentoctl/utils.py
+++ b/py_bentoctl/utils.py
@@ -2,6 +2,7 @@ import docker
 import sys
 import os
 
+from kubernetes import client, config as k8s_config
 from termcolor import cprint
 
 __all__ = [
@@ -12,6 +13,7 @@ __all__ = [
     "err",
     "indent_str",
     "get_docker_client",
+    "get_k8s_client",
     "getenv_or_exit",
 ]
 
@@ -42,6 +44,11 @@ def indent_str(msg: str, n: int) -> str:
 
 def get_docker_client() -> docker.DockerClient:
     return docker.from_env()
+
+
+def get_k8s_client() -> client.CoreV1Api:
+    k8s_config.load_incluster_config()
+    return client.CoreV1Api()
 
 
 def getenv_or_exit(var: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tqdm==4.67.3
 typing_extensions==4.15.0
 urllib3==2.7.0
 websocket-client==1.9.0
+kubernetes==36.0.3


### PR DESCRIPTION
Adds a Dockerfile and GitHub Actions workflow to build and publish `bentoctl` as a Docker image, so it can be used as a k8s Job image to run `bentoctl init-auth` for Keycloak initialization.

- Adds `Dockerfile`: Python 3.14 base image, installs the Docker CLI and compose plugin via Docker's official apt repo (Debian's `docker.io` package doesn't ship a client binary), copies in `lib/` and the compose files since `config.py` runs `docker compose config` at import time, sets up a venv, and creates a `bentoctl` shell alias
- Adds `dev.Dockerfile`: mirrors `Dockerfile` minus the `py_bentoctl` source copy, since dev images should have dependencies pre-built with the source mounted in as a volume for local iteration
- Adds `.github/workflows/build.yml`: builds and smoke-tests both the main and dev images, then publishes to `ghcr.io/bento-platform/bentoctl` via `bento_build_action` on pushes/PRs to `main` and published releases
- Fixes `init-auth`'s hard dependency on a Docker daemon (#361): `docker_client` is now optional in `auth_helper.py`, `entry.py` only builds a Docker client when `BENTOV2_USE_EXTERNAL_IDP` is false, and a new `BENTOV2_AUTH_CREATE_TEST_USER` env var allows test user creation to be forced on for external IdPs
- Fixes a second Docker Compose dependency in `config.py`: service enumeration via `docker compose config` ran unconditionally at import time and crashed without a full local Compose environment. Adds a new `BENTO_PLATFORM` env var (`docker`/`kubernetes`) to skip this when not running under Docker Compose

Testing: Built and ran both images locally, confirming the smoke test passes with exit code 0 for each. Also rebuilt the image with the `init-auth` fixes and confirmed `bentoctl init-auth` no longer crashes on `docker.from_env()` or `docker compose config` when run with `BENTOV2_USE_EXTERNAL_IDP=true` and `BENTO_PLATFORM=kubernetes` — it proceeds into the real Keycloak auth flow and successfully reaches the point of making an authenticated request against a live Keycloak instance.

Closes #359
Closes #361