### PR TITLE
OIDC secret automation bentoctl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,20 @@ jobs:
       - name: Test image (show help output)
         run: docker run bentoctl:test bentoctl
 
+      - name: Build dev image for testing
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: dev.Dockerfile
+          push: false
+          load: true
+          tags: ghcr.io/bento-platform/bentoctl:test-dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test dev image (show help output)
+        run: docker run -v ./py_bentoctl:/bentoctl/py_bentoctl ghcr.io/bento-platform/bentoctl:test-dev bentoctl
+
       - name: Run Bento build action
         uses: bento-platform/bento_build_action@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build and push bentoctl
+on:
+  release:
+    types: [ published ]
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build-test-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image for testing
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: bentoctl:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test image (show help output)
+        run: docker run bentoctl:test bentoctl
+
+      - name: Run Bento build action
+        uses: bento-platform/bento_build_action@v1
+        with:
+          registry: ghcr.io
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+          image-name: ghcr.io/bento-platform/bentoctl
+          development-dockerfile: dev.Dockerfile
+          dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM python:3.14-slim
+
+WORKDIR /bentoctl
+
+# docker compose config (used by py_bentoctl/config.py to enumerate enabled services) needs the
+# docker CLI + compose plugin present, even though no daemon is running in this container.
+# Debian's own `docker.io` package doesn't ship a `docker` client binary, so we use Docker's
+# official apt repo instead, and only install the CLI + compose plugin (no engine/daemon).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY py_bentoctl py_bentoctl
+COPY requirements.txt .
+COPY bentoctl.bash .
+COPY docker-compose.yaml .
+COPY lib lib
+COPY etc/default_config.env etc/default_config.env
+COPY etc/bento.env etc/bento.env
+COPY etc/bento_post_config.bash etc/bento_post_config.bash
+COPY etc/bento_services.json etc/bento_services.json
+
+RUN chmod +x bentoctl.bash
+
+# Create and activate a venv, then install Python dependencies into it
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Create a `bentoctl` shell alias for bentoctl.bash
+RUN echo "alias bentoctl='/bentoctl/bentoctl.bash'" >> /etc/bash.bashrc
+
+# Use an interactive shell as the entrypoint so the alias above is picked up
+# even for non-interactive `docker run <image> bentoctl` invocations.
+ENTRYPOINT [ "/bin/bash", "-ic" ]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin && \
     rm -rf /var/lib/apt/lists/*
 
-COPY py_bentoctl py_bentoctl
 COPY requirements.txt .
 COPY bentoctl.bash .
 COPY docker-compose.yaml .

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,43 @@
+# NOTE: bentoctl has no real "dev" mode/workflow at the moment — this file exists only because
+# bento_build_action currently requires a development-dockerfile input to build from.
+# It mirrors Dockerfile for now.
+# TODO: remove this once bento_build_action supports an optional dev Dockerfile.
+
+FROM python:3.14-slim
+
+WORKDIR /bentoctl
+
+# docker compose config (used by py_bentoctl/config.py to enumerate enabled services) needs the
+# docker CLI + compose plugin present, even though no daemon is running in this container.
+# Debian's own `docker.io` package doesn't ship a `docker` client binary, so we use Docker's
+# official apt repo instead, and only install the CLI + compose plugin (no engine/daemon).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY py_bentoctl py_bentoctl
+COPY requirements.txt .
+COPY bentoctl.bash .
+COPY docker-compose.yaml .
+COPY lib lib
+COPY etc/default_config.env etc/default_config.env
+COPY etc/bento.env etc/bento.env
+COPY etc/bento_post_config.bash etc/bento_post_config.bash
+COPY etc/bento_services.json etc/bento_services.json
+
+RUN chmod +x bentoctl.bash
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install --no-cache-dir -r requirements.txt
+
+RUN echo "alias bentoctl='/bentoctl/bentoctl.bash'" >> /etc/bash.bashrc
+
+ENTRYPOINT [ "/bin/bash", "-ic" ]

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -23,7 +23,7 @@ __all__ = ["init_auth"]
 urllib3.disable_warnings(InsecureRequestWarning)
 
 USE_EXTERNAL_IDP = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
-CREATE_TEST_USER = os.getenv("BENTOV2_AUTH_CREATE_TEST_USER") in ("1", "true")
+CREATE_TEST_USER = os.getenv("BENTO_AUTH_CREATE_TEST_USER") in ("1", "true")
 CLIENT_ID = os.getenv("BENTOV2_AUTH_CLIENT_ID")
 
 PUBLIC_URL = os.getenv("BENTOV2_PUBLIC_URL")
@@ -642,12 +642,12 @@ def init_auth(docker_client: Optional[docker.DockerClient] = None):
         )
         success()
 
-    if not USE_EXTERNAL_IDP or CREATE_TEST_USER:
+    if CREATE_TEST_USER:
         info(f"  Creating user: {AUTH_TEST_USER}")
         create_test_user_if_needed(access_token)
         success()
     else:
-        warn("  Skipping test user creation as we are using an external Keycloak instance.")
+        warn("  Skipping test user creation, set BENTO_AUTH_CREATE_TEST_USER=true to enable it.")
 
     if not USE_EXTERNAL_IDP:
         if docker_client is not None:

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -23,6 +23,7 @@ __all__ = ["init_auth"]
 urllib3.disable_warnings(InsecureRequestWarning)
 
 USE_EXTERNAL_IDP = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
+CREATE_TEST_USER = os.getenv("BENTOV2_AUTH_CREATE_TEST_USER") in ("1", "true")
 CLIENT_ID = os.getenv("BENTOV2_AUTH_CLIENT_ID")
 
 PUBLIC_URL = os.getenv("BENTOV2_PUBLIC_URL")
@@ -334,7 +335,7 @@ def create_client_and_secret_for_service(
     )
 
 
-def init_auth(docker_client: docker.DockerClient):
+def init_auth(docker_client: Optional[docker.DockerClient] = None):
     target_realm = AUTH_REALM if USE_EXTERNAL_IDP else MASTER_REALM
 
     # Capture admin credentials from the function
@@ -586,14 +587,15 @@ def init_auth(docker_client: docker.DockerClient):
     idp_type = "external" if USE_EXTERNAL_IDP else "internal"
     info(f"[bentoctl] Using {idp_type} IdP, setting up Keycloak... (DEV_MODE={c.DEV_MODE})")
 
-    try:
-        docker_client.containers.get(GATEWAY_CONTAINER_NAME)  # Needed to access Keycloak through the proper channel
-        docker_client.containers.get(AUTH_CONTAINER_NAME)
-    except requests.exceptions.HTTPError:
-        info(f"  Starting {AUTH_CONTAINER_NAME}...")
-        # Not found, so we need to start it
-        subprocess.check_call((*c.COMPOSE, "up", "--wait", "-d", "auth", "gateway"))
-        success()
+    if docker_client is not None:
+        try:
+            docker_client.containers.get(GATEWAY_CONTAINER_NAME)  # Needed to access Keycloak through the proper channel
+            docker_client.containers.get(AUTH_CONTAINER_NAME)
+        except requests.exceptions.HTTPError:
+            info(f"  Starting {AUTH_CONTAINER_NAME}...")
+            # Not found, so we need to start it
+            subprocess.check_call((*c.COMPOSE, "up", "--wait", "-d", "auth", "gateway"))
+            success()
 
     info(f"   Signing into {target_realm} realm as {AUTH_ADMIN_USER}...")
     session = get_session()
@@ -640,7 +642,7 @@ def init_auth(docker_client: docker.DockerClient):
         )
         success()
 
-    if not USE_EXTERNAL_IDP:
+    if not USE_EXTERNAL_IDP or CREATE_TEST_USER:
         info(f"  Creating user: {AUTH_TEST_USER}")
         create_test_user_if_needed(access_token)
         success()
@@ -648,14 +650,15 @@ def init_auth(docker_client: docker.DockerClient):
         warn("  Skipping test user creation as we are using an external Keycloak instance.")
 
     if not USE_EXTERNAL_IDP:
-        info("  Restarting the Keycloak container")
-        try:
-            kc = docker_client.containers.get(AUTH_CONTAINER_NAME)
-            kc.restart()
-            success()
-        except requests.exceptions.HTTPError:
-            # Not found
-            err(f"    Could not find container: {AUTH_CONTAINER_NAME}. Is it running?")
+        if docker_client is not None:
+            info("  Restarting the Keycloak container")
+            try:
+                kc = docker_client.containers.get(AUTH_CONTAINER_NAME)
+                kc.restart()
+                success()
+            except requests.exceptions.HTTPError:
+                # Not found
+                err(f"    Could not find container: {AUTH_CONTAINER_NAME}. Is it running?")
 
     if not USE_EXTERNAL_IDP:
         # Copy branding file from cwd/etc/default.branding.lightbg.png

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -2,6 +2,7 @@
 
 import docker
 import json
+from kubernetes import client, config as k8s_config
 import os
 import requests
 import subprocess
@@ -300,6 +301,7 @@ def create_client_and_secret_for_service(
     to_restart: str = "the gateway",
     token_lifespan: int = 900,    # default access token lifespan: 15 minutes
     use_refresh_tokens: bool = False,  # by default, don't use refresh tokens! (they're less secure)
+    k8s_client: Optional[client.CoreV1Api] = None,
 ):
     client_kc_id: Optional[str] = fetch_existing_client_id(token, client_id)
 
@@ -335,9 +337,25 @@ def create_client_and_secret_for_service(
         attrs=["bold"],
     )
 
+    if k8s_client is not None:
+        secret_name = f"{client_id}-oidc-secret"
+        k8s_client.create_namespaced_secret(
+            namespace="default",
+            body=client.V1Secret(
+                metadata=client.V1ObjectMeta(name=secret_name),
+                string_data={"id": client_kc_id, "secret": client_secret},
+            ),
+        )
+        info(f"    Created Kubernetes secret: {secret_name}")
+
 
 def init_auth(docker_client: Optional[docker.DockerClient] = None):
     target_realm = AUTH_ADMIN_REALM or (AUTH_REALM if USE_EXTERNAL_IDP else MASTER_REALM)
+
+    k8s_client = None
+    if c.BENTO_PLATFORM == "kubernetes":
+        k8s_config.load_incluster_config()
+        k8s_client = client.CoreV1Api()
 
     # Capture admin credentials from the function
     admin_user, admin_password = get_admin_credentials()
@@ -445,7 +463,8 @@ def init_auth(docker_client: Optional[docker.DockerClient] = None):
 
     def create_grafana_client_if_needed(token: str) -> None:
         create_client_and_secret_for_service(
-            GRAFANA_CLIENT_ID, "BENTO_GRAFANA_CLIENT_SECRET", GRAFANA_PRIVATE_URL, token, to_restart="Grafana"
+            GRAFANA_CLIENT_ID, "BENTO_GRAFANA_CLIENT_SECRET", GRAFANA_PRIVATE_URL, token, to_restart="Grafana",
+            k8s_client=k8s_client,
         )
 
     def create_grafana_client_roles_if_needed(token: str, client_id: str) -> Optional[dict]:
@@ -519,12 +538,14 @@ def init_auth(docker_client: Optional[docker.DockerClient] = None):
             token,
             is_service_account=True,
             to_restart="Aggregation and Beacon",
+            k8s_client=k8s_client,
         )
 
     # noinspection PyUnusedLocal
     def create_cbioportal_client_if_needed(token: str) -> None:
         create_client_and_secret_for_service(
-            CBIOPORTAL_CLIENT_ID, "BENTO_CBIOPORTAL_CLIENT_SECRET", CBIOPORTAL_URL, token, use_refresh_tokens=True
+            CBIOPORTAL_CLIENT_ID, "BENTO_CBIOPORTAL_CLIENT_SECRET", CBIOPORTAL_URL, token, use_refresh_tokens=True,
+            k8s_client=k8s_client,
         )
 
     def create_wes_client_if_needed(token: str) -> None:
@@ -536,6 +557,7 @@ def init_auth(docker_client: Optional[docker.DockerClient] = None):
             is_service_account=True,
             to_restart="WES",
             token_lifespan=WES_WORKFLOW_TIMEOUT,
+            k8s_client=k8s_client,
         )
 
     def create_test_user_if_needed(token: str) -> None:

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -339,6 +339,11 @@ def create_client_and_secret_for_service(
 
     if k8s_client is not None:
         secret_name = f"{client_id}-oidc-secret"
+        try:
+            k8s_client.delete_namespaced_secret(name=secret_name, namespace="default")
+        except client.exceptions.ApiException as e:
+            if e.status != 404:
+                raise
         k8s_client.create_namespaced_secret(
             namespace="default",
             body=client.V1Secret(

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -24,6 +24,7 @@ urllib3.disable_warnings(InsecureRequestWarning)
 
 USE_EXTERNAL_IDP = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
 CREATE_TEST_USER = os.getenv("BENTO_AUTH_CREATE_TEST_USER") in ("1", "true")
+AUTH_ADMIN_REALM = os.getenv("BENTO_AUTH_ADMIN_REALM", "")
 CLIENT_ID = os.getenv("BENTOV2_AUTH_CLIENT_ID")
 
 PUBLIC_URL = os.getenv("BENTOV2_PUBLIC_URL")
@@ -336,7 +337,7 @@ def create_client_and_secret_for_service(
 
 
 def init_auth(docker_client: Optional[docker.DockerClient] = None):
-    target_realm = AUTH_REALM if USE_EXTERNAL_IDP else MASTER_REALM
+    target_realm = AUTH_ADMIN_REALM or (AUTH_REALM if USE_EXTERNAL_IDP else MASTER_REALM)
 
     # Capture admin credentials from the function
     admin_user, admin_password = get_admin_credentials()

--- a/py_bentoctl/auth_helper.py
+++ b/py_bentoctl/auth_helper.py
@@ -120,11 +120,11 @@ def fetch_existing_client_id(token: str, client_id: str, verbose: bool = True) -
         err(f"    Failed to fetch existing clients: {existing_clients}")
         exit(1)
 
-    for client in existing_clients:
-        if client["clientId"] == client_id:
+    for kc_client in existing_clients:
+        if kc_client["clientId"] == client_id:
             if verbose:
                 warn(f"    Found existing client: {client_id}; using that.")
-            return client["id"]
+            return kc_client["id"]
 
     return None
 

--- a/py_bentoctl/config.py
+++ b/py_bentoctl/config.py
@@ -29,6 +29,7 @@ __all__ = [
 
     "MODE",
     "DEV_MODE",
+    "BENTO_PLATFORM",
 
     "BENTO_OPTIONAL_FEATURES",
     "BENTO_OPTIONAL_FEATURES_BY_PROFILE",
@@ -71,6 +72,8 @@ BENTO_USERNAME: str = pwd.getpwuid(BENTO_UID).pw_name
 
 MODE = os.getenv("MODE")
 DEV_MODE = MODE == "dev"
+
+BENTO_PLATFORM = os.getenv("BENTO_PLATFORM", "docker")
 
 SERVICE_LITERAL_ALL: str = "all"
 
@@ -165,16 +168,23 @@ def _get_enabled_services(
                 break  # escape profile loop, we found one which enables this service
 
 
-BASE_SERVICES: Tuple[str, ...] = tuple(_get_enabled_services((DOCKER_COMPOSE_FILE_BASE,), ()))
+if BENTO_PLATFORM == "docker":
+    BASE_SERVICES: Tuple[str, ...] = tuple(_get_enabled_services((DOCKER_COMPOSE_FILE_BASE,), ()))
 
-# Load dev docker-compose services list if in DEV_MODE
-DOCKER_COMPOSE_DEV_SERVICES: Tuple[str, ...] = tuple(
-    _get_enabled_services((DOCKER_COMPOSE_FILE_BASE, DOCKER_COMPOSE_FILE_DEV), BASE_SERVICES)) if DEV_MODE else ()
+    # Load dev docker-compose services list if in DEV_MODE
+    DOCKER_COMPOSE_DEV_SERVICES: Tuple[str, ...] = tuple(
+        _get_enabled_services((DOCKER_COMPOSE_FILE_BASE, DOCKER_COMPOSE_FILE_DEV), BASE_SERVICES)) if DEV_MODE else ()
 
-# Final amalgamation of services for Bento taking into account dev/prod mode + profiles
-DOCKER_COMPOSE_SERVICES: Tuple[str, ...] = BASE_SERVICES + DOCKER_COMPOSE_DEV_SERVICES
-# For use by CLI service arguments: adds in an `all` option, meaning all services:
-DOCKER_COMPOSE_SERVICES_PLUS_ALL: Tuple[str, ...] = (*DOCKER_COMPOSE_SERVICES, SERVICE_LITERAL_ALL)
+    # Final amalgamation of services for Bento taking into account dev/prod mode + profiles
+    DOCKER_COMPOSE_SERVICES: Tuple[str, ...] = BASE_SERVICES + DOCKER_COMPOSE_DEV_SERVICES
+    # For use by CLI service arguments: adds in an `all` option, meaning all services:
+    DOCKER_COMPOSE_SERVICES_PLUS_ALL: Tuple[str, ...] = (*DOCKER_COMPOSE_SERVICES, SERVICE_LITERAL_ALL)
+else:
+    # Not a Docker Compose deployment (e.g. Kubernetes) - Compose services aren't applicable.
+    BASE_SERVICES: Tuple[str, ...] = ()
+    DOCKER_COMPOSE_DEV_SERVICES: Tuple[str, ...] = ()
+    DOCKER_COMPOSE_SERVICES: Tuple[str, ...] = ()
+    DOCKER_COMPOSE_SERVICES_PLUS_ALL: Tuple[str, ...] = (SERVICE_LITERAL_ALL,)
 
 
 BENTO_SERVICES_PATH = os.getenv("BENTO_SERVICES", pathlib.Path(__file__).parent.parent / "etc" / "bento_services.json")

--- a/py_bentoctl/entry.py
+++ b/py_bentoctl/entry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import argparse
+import os
 import subprocess
 import sys
 
@@ -33,7 +34,8 @@ class InitAuth(SubCommand):
 
     @staticmethod
     def exec(args):
-        init_auth(docker_client=u.get_docker_client())
+        use_external_idp = os.getenv("BENTOV2_USE_EXTERNAL_IDP") in ("1", "true")
+        init_auth(docker_client=None if use_external_idp else u.get_docker_client())
 
 
 class Run(SubCommand):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tqdm==4.67.3
 typing_extensions==4.15.0
 urllib3==2.7.0
 websocket-client==1.9.0
+kubernetes==36.0.3


### PR DESCRIPTION
Follow-up to the RBAC work in bento-helm-charts PR #56. init-auth now creates the OIDC client secrets directly in Kubernetes instead of only printing them for a manual `kubectl create secret`.

## Changes

- Added `kubernetes==36.0.3` to requirements.txt
- In `init_auth`, build a `CoreV1Api` client via in-cluster config when `BENTO_PLATFORM` is `kubernetes`, and pass it down to `create_client_and_secret_for_service`
- That function now creates a Secret named `<client_id>-oidc-secret` with `id` and `secret` keys via `stringData` for each OIDC client, alongside the existing print
- Before creating, it deletes any existing secret of the same name first, so reruns of init-auth are idempotent instead of crashing with a 409 Conflict when the secret already exists

## Testing

- Built a local image and ran init-auth against a real cluster twice back to back
- The first run created `aggregation-oidc-secret` and `wes-oidc-secret`, and I confirmed the contents matched the values Keycloak actually returned rather than just checking the run succeeded
- Before adding the delete-first fix, the second run crashed with a 409 Conflict partway through, leaving the aggregation secret recreated but WES never reached
- After the fix, with the delete verb applied from the RBAC PR, the second run completed cleanly and both secrets came back with fresh creationTimestamps confirming they were actually replaced rather than left stale