### PR TITLE
chore: update public repo dev volume mounts for next-app structure

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -16,15 +16,15 @@ services:
     volumes:
       - ./repos/public:/bento-public
       - ./packs:/packs
-      - ${PWD}/lib/public/en_about.html:/bento-public/next-app/public/public/en_about.html
-      - ${PWD}/lib/public/fr_about.html:/bento-public/next-app/public/public/fr_about.html
-      - ${PWD}/lib/public/branding.png:/bento-public/next-app/public/public/assets/branding.png
-      - ${PWD}/lib/public/branding.fr.png:/bento-public/next-app/public/public/assets/branding.fr.png
-      - ${PWD}/lib/public/branding.lightbg.png:/bento-public/next-app/public/public/assets/branding.lightbg.png
-      - ${PWD}/lib/public/branding.lightbg.fr.png:/bento-public/next-app/public/public/assets/branding.lightbg.fr.png
-      - ${PWD}/lib/public/translations/en.json:/bento-public/next-app/public/public/locales/en/translation_en.json
-      - ${PWD}/lib/public/translations/fr.json:/bento-public/next-app/public/public/locales/fr/translation_fr.json
-      - ${PWD}/lib/public/instance.css:/bento-public/next-app/public/public/styles/instance.css:ro
+      - ${PWD}/lib/public/en_about.html:/bento-public/public/public/en_about.html
+      - ${PWD}/lib/public/fr_about.html:/bento-public/public/public/fr_about.html
+      - ${PWD}/lib/public/branding.png:/bento-public/public/public/assets/branding.png
+      - ${PWD}/lib/public/branding.fr.png:/bento-public/public/public/assets/branding.fr.png
+      - ${PWD}/lib/public/branding.lightbg.png:/bento-public/public/public/assets/branding.lightbg.png
+      - ${PWD}/lib/public/branding.lightbg.fr.png:/bento-public/public/public/assets/branding.lightbg.fr.png
+      - ${PWD}/lib/public/translations/en.json:/bento-public/public/public/locales/en/translation_en.json
+      - ${PWD}/lib/public/translations/fr.json:/bento-public/public/public/locales/fr/translation_fr.json
+      - ${PWD}/lib/public/instance.css:/bento-public/public/public/styles/instance.css:ro
     environment:
       - BENTO_GIT_NAME
       - BENTO_GIT_EMAIL

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -16,15 +16,15 @@ services:
     volumes:
       - ./repos/public:/bento-public
       - ./packs:/packs
-      - ${PWD}/lib/public/en_about.html:/bento-public/src/public/en_about.html
-      - ${PWD}/lib/public/fr_about.html:/bento-public/src/public/fr_about.html
-      - ${PWD}/lib/public/branding.png:/bento-public/src/public/assets/branding.png
-      - ${PWD}/lib/public/branding.fr.png:/bento-public/src/public/assets/branding.fr.png
-      - ${PWD}/lib/public/branding.lightbg.png:/bento-public/src/public/assets/branding.lightbg.png
-      - ${PWD}/lib/public/branding.lightbg.fr.png:/bento-public/src/public/assets/branding.lightbg.fr.png
-      - ${PWD}/lib/public/translations/en.json:/bento-public/src/public/locales/en/translation_en.json
-      - ${PWD}/lib/public/translations/fr.json:/bento-public/src/public/locales/fr/translation_fr.json
-      - ${PWD}/lib/public/instance.css:/bento-public/src/public/styles/instance.css:ro
+      - ${PWD}/lib/public/en_about.html:/bento-public/next-app/public/public/en_about.html
+      - ${PWD}/lib/public/fr_about.html:/bento-public/next-app/public/public/fr_about.html
+      - ${PWD}/lib/public/branding.png:/bento-public/next-app/public/public/assets/branding.png
+      - ${PWD}/lib/public/branding.fr.png:/bento-public/next-app/public/public/assets/branding.fr.png
+      - ${PWD}/lib/public/branding.lightbg.png:/bento-public/next-app/public/public/assets/branding.lightbg.png
+      - ${PWD}/lib/public/branding.lightbg.fr.png:/bento-public/next-app/public/public/assets/branding.lightbg.fr.png
+      - ${PWD}/lib/public/translations/en.json:/bento-public/next-app/public/public/locales/en/translation_en.json
+      - ${PWD}/lib/public/translations/fr.json:/bento-public/next-app/public/public/locales/fr/translation_fr.json
+      - ${PWD}/lib/public/instance.css:/bento-public/next-app/public/public/styles/instance.css:ro
     environment:
       - BENTO_GIT_NAME
       - BENTO_GIT_EMAIL


### PR DESCRIPTION
## Summary
- bento-public's public assets moved from `src/public` to `public/public`
